### PR TITLE
email field is mandatory - set default. fix typo

### DIFF
--- a/vycontrol/accounts/views.py
+++ b/vycontrol/accounts/views.py
@@ -28,7 +28,7 @@ def index(request):
             return redirect('registration-login')
     else:
         if 'username' in request.POST and 'password' in request.POST:
-            user = User.objects.create_superuser(username=request.POST['username'], password=request.POST['password'])
+            user = User.objects.create_superuser(username=request.POST['username'], email='', password=request.POST['password'])
             user.save()
             return redirect('%s?next=%s' % (reverse('registration-login'), '/config/instance-add'))
     template = loader.get_template('registration/start.html')

--- a/vycontrol/firewall/templates/firewall/list.html
+++ b/vycontrol/firewall/templates/firewall/list.html
@@ -28,7 +28,7 @@
     <tr>
         <th>name</th>
         <th>description</th>
-        <th>default-acton</th>
+        <th>default-action</th>
         <th>actions</th>
     </tr>
 


### PR DESCRIPTION
Built per instructions and ran command line version (this doesn't happen in docker-compose built pull).
Initial admin user creation fails: File "/Users/Neil/go/src/github.com/britannic/vycontrol/vycontrol/accounts/views.py", line 31, in index
user = User.objects.create_superuser(username=request.POST['username'], password=request.POST['password'])
TypeError: create_superuser() missing 1 required positional argument: 'email'

Fixed a minor typo in Firewall List headers.